### PR TITLE
Cut scene skip

### DIFF
--- a/AutoSteamApp/Core/Settings.cs
+++ b/AutoSteamApp/Core/Settings.cs
@@ -148,5 +148,37 @@ namespace AutoSteamApp.Core
                 return (_keyCodeStop = 27);
             }
         }
+        
+        private static int _keyCutsceneSkip = -1;
+        public static int KeyCutsceneSkip
+        {
+            get
+            {
+                if (_keyCutsceneSkip != -1) { return _keyCutsceneSkip; }
+
+                if (ConfigurationManager.AppSettings.AllKeys.Any(key => key == "keyCutsceneSkip"))
+                {
+                    if (int.TryParse(ConfigurationManager.AppSettings["keyCutsceneSkip"].Trim(), out _keyCutsceneSkip))
+                    {
+                        try
+                        {
+                            KeyCode key = (KeyCode)_keyCutsceneSkip;
+
+                            return _keyCutsceneSkip;
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogError($"Invalid number for 'CutsceneSkip' keycode: [{_keyCutsceneSkip}]. Will use default instead! Exception: {ex.Message}");
+                        }
+                    }
+                }
+                else
+                {
+                    Logger.LogError($"Invalid number for 'CutsceneSkip' keycode: [{ConfigurationManager.AppSettings["keyCutsceneSkip"]}]. Will use default instead!");
+                }
+
+                return (_keyCutsceneSkip = 88);
+            }
+        }
     }
 }

--- a/AutoSteamApp/Program.cs
+++ b/AutoSteamApp/Program.cs
@@ -122,6 +122,8 @@ namespace AutoSteamApp
 
                         try
                         {
+                            PressKey(sim, (VirtualKeyCode)Settings.KeyCutsceneSkip);
+
                             // no more fuel
                             if (currentState == (int)ButtonPressingState.EndOfGame)
                             {

--- a/AutoSteamApp/app.config
+++ b/AutoSteamApp/app.config
@@ -17,5 +17,9 @@
     <add key="keyCodeStart" value="36" />
     <!-- 27 = escape-->
     <add key="keyCodeStop" value="35" />
+
+    <!-- System > Options > Controls > Keyboard Settings > Menu Control > "Use or Register Loadout / Cancel Animation" -->
+    <!-- 88 = "X"-->
+    <add key="keyCutsceneSkip" value="88" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
Skips cutscene at the end using ingame 
System > Options > Controls > Keyboard Settings > Menu Control > "Use or Register Loadout / Cancel Animation"
default keybind = "X" configurable via app.config