### PR TITLE
Fix steamworks combo memory address

### DIFF
--- a/AutoSteamApp/Core/Settings.cs
+++ b/AutoSteamApp/Core/Settings.cs
@@ -8,10 +8,10 @@ namespace AutoSteamApp.Core
     public static class Settings
     {
         #region magic numbers
-        public static string SupportedGameVersion = "404549";
+        public static string SupportedGameVersion = "406510";
 
         public static ulong Off_Base = 0x140000000;
-        public static ulong Off_SteamworksCombo = 0x4D6B970; 
+        public static ulong Off_SteamworksCombo = 0x04E3E220; 
         
         public static ulong Off_SaveData = 0x4DF6F00;
         public static ulong Off_DiffSlot = 0x27E9F0; // start of each save slot data slotnr * off

--- a/AutoSteamApp/Program.cs
+++ b/AutoSteamApp/Program.cs
@@ -160,7 +160,7 @@ namespace AutoSteamApp
             if (mhw != null && !ct.IsCancellationRequested)
             {
                 InputSimulator sim = new InputSimulator();
-                SaveData sd = new SaveData(mhw, ct);
+                // SaveData sd = new SaveData(mhw, ct);
 
                 ulong starter = Settings.Off_Base + Settings.Off_SteamworksCombo;
 
@@ -171,7 +171,7 @@ namespace AutoSteamApp
 
                 while (!shouldStop && !ct.IsCancellationRequested)
                 {
-                    Logger.LogInfo($"Gauge Data {sd.SteamGauge}!");
+                    // Logger.LogInfo($"Gauge Data {sd.SteamGauge}!");
 
                     // value of the offset address
                     var ordered = ExtractCorrectSequence(mhw, offset_Address);
@@ -226,17 +226,17 @@ namespace AutoSteamApp
                             // no more fuel
                             if (currentState == (int)ButtonPressingState.EndOfGame)
                             {
-                                if (sd.NaturalFuel + sd.StoredFuel < 10)
-                                {
-                                    Logger.LogInfo("No more fuel, stopping bot.");
-                                    shouldStop = true;
-                                    break;
-                                }
-
-                                if (sd.SteamGauge == 0)
-                                {
+                                // if (sd.NaturalFuel + sd.StoredFuel < 10)
+                                // {
+                                //     Logger.LogInfo("No more fuel, stopping bot.");
+                                //     shouldStop = true;
+                                //     break;
+                                // }
+                                // 
+                                // if (sd.SteamGauge == 0)
+                                // {
                                     PressKey(sim, VirtualKeyCode.SPACE);
-                                }
+                                // }
                             }
 
                             if (shouldStop)


### PR DESCRIPTION
Hotfix for #11 

Keep in mind I had to disable the parts that read from save data for this to work. Which means the app doesn't check for fuel and doesn't auto close anymore when done.